### PR TITLE
build(deps-dev): bump js-yaml to 3.15.1 and 4.3.1 for CVE-2026-59869

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -800,9 +800,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4819,10 +4819,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
Clears two Dependabot alerts for **CVE-2026-59869** (high) — *YAML merge-key chains can force quadratic CPU consumption*. The advisory covers two version ranges, and this repo has one instance in each, so a single `npm update js-yaml` closes both.

| Instance | Was | Now | Reached via | Parent's range | Affected range |
|---|---|---|---|---|---|
| `node_modules/js-yaml` | 4.1.1 | **4.3.1** | `@eslint/eslintrc` | `^4.1.0` | `>= 4.0.0, < 4.3.0` |
| `…/@istanbuljs/load-nyc-config/…/js-yaml` | 3.14.2 | **3.15.1** | `@istanbuljs/load-nyc-config` | `^3.13.1` | `>= 3.0.0, < 3.15.0` |

## Just the required change

Both are **dev-scope**. No manifest edit is needed — each parent already declares a range that admits the patched release, so `npm update js-yaml` refreshes the stale lockfile pins in place.

**`package-lock.json` is the only file touched. No source changes.** The dependency graph is unchanged (`argparse ^2.0.1` either side); the extra lines in the diff are a `funding` metadata block npm copies from the new package.

An `overrides` block was deliberately avoided — it would pin both versions permanently and force a manual bump for every future patch instead of letting the existing ranges do their job.

## Verification (Node 20.20.2 / npm 10.8.2)

| Check | Result |
|---|---|
| `npm audit` | **js-yaml CLEAN** (7 → 6 vulnerabilities, high 3 → 2) |
| `npm run build` | exit 0 — all three `tsc` targets emit `dist-*` |
| `npm run lint` | exit 0, zero files rewritten |
| Files changed | `package-lock.json` only |

**Behavioural equivalence** — old vs new on each major line, across 10 YAML documents (scalars, nesting, block and folded strings, anchors, merge keys, dates, empty collections):

- 3.x `load`: **10/10 identical**, `dump`: 3/3
- 4.x `load`: **10/10 identical**, `dump`: 3/3

## CVE reproduced and confirmed fixed

Chained merge keys — the exact vector in the advisory:

| Chain depth | 3.14.2 → 3.15.1 | 4.1.1 → 4.3.1 |
|---|---|---|
| 200 | 6.4 ms → 3.4 ms | 4.0 ms → 3.4 ms |
| 500 | 14.7 ms → 1.7 ms | 15.2 ms → 3.1 ms |
| 1,000 | 49.1 ms → 1.6 ms | 49.8 ms → 1.6 ms |
| 1,500 | **117.9 ms → 1.1 ms** | **113.4 ms → 1.4 ms** |

7.5× the input gives ~18× the time on the old versions; the patched ones stay flat.

## Note on `npm test`

It passes, but it isn't evidence — both suites are placeholder stubs. The build, lint and the differential carry the verification here.
